### PR TITLE
feat(terminal): neofetch, man meik and experience as interactive commands

### DIFF
--- a/e2e/easter-egg.spec.ts
+++ b/e2e/easter-egg.spec.ts
@@ -68,6 +68,40 @@ test.describe('Interactive terminal', () => {
       { timeout: 5000 },
     );
   });
+
+  test('neofetch command shows name and role in output', async ({ page }) => {
+    await page.keyboard.type('neofetch');
+    await page.keyboard.press('Enter');
+    const output = page.locator('#ts-cmd-output').last();
+    await expect(output).toContainText('Meik Geldmacher');
+    await expect(output).toContainText('Solution');
+  });
+
+  test('man meik command shows man page in output', async ({ page }) => {
+    await page.keyboard.type('man meik');
+    await page.keyboard.press('Enter');
+    const output = page.locator('#ts-cmd-output').last();
+    await expect(output).toContainText('NAME');
+    await expect(output).toContainText('DESCRIPTION');
+  });
+
+  test('column -t experience.tsv command shows experience table in output', async ({ page }) => {
+    await page.keyboard.type('column -t experience.tsv');
+    await page.keyboard.press('Enter');
+    const output = page.locator('#ts-cmd-output').last();
+    await expect(output).toContainText('PERIOD');
+    await expect(output).toContainText('ROLE');
+    await expect(output).toContainText('COMPANY');
+  });
+
+  test('help lists neofetch, man meik and experience commands', async ({ page }) => {
+    await page.keyboard.type('help');
+    await page.keyboard.press('Enter');
+    const response = page.locator('#ts-cmd-output .cmd-response').last();
+    await expect(response).toContainText('neofetch');
+    await expect(response).toContainText('man meik');
+    await expect(response).toContainText('column -t experience.tsv');
+  });
 });
 
 test.describe('Easter egg', () => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -941,14 +941,17 @@ const experienceYears = currentYear - 2012;
       help: () =>
         [
           `<span class="cmd-success">available commands:</span>`,
-          `  help                      show this help`,
-          `  whoami                    who are you?`,
-          `  clear                     clear terminal output`,
-          `  ls                        list files`,
-          `  cat .secret               read a secret file`,
-          `  make coffee               ☕`,
-          `  sudo make me a sandwich   classic`,
-          `  exit                      close the terminal`,
+          `  help                        show this help`,
+          `  whoami                      who are you?`,
+          `  clear                       clear terminal output`,
+          `  ls                          list files`,
+          `  cat .secret                 read a secret file`,
+          `  neofetch                    system info`,
+          `  man meik                    read the manual`,
+          `  column -t experience.tsv    experience timeline`,
+          `  make coffee                 ☕`,
+          `  sudo make me a sandwich     classic`,
+          `  exit                        close the terminal`,
         ].join('\n'),
       whoami: () =>
         `a curious human who reads other people's portfolio websites at ${new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })}`,
@@ -1022,6 +1025,26 @@ const experienceYears = currentYear - 2012;
       if (promptLine) promptLine.style.visibility = visible ? '' : 'hidden';
     }
 
+    function appendClonedSection(cmd: string, sourceEl: Element) {
+      const block = document.createElement('div');
+      block.innerHTML = `
+        <div class="cmd-line">
+          <span style="color:#27c93f;font-weight:700">meik@tomatenstau.de</span><span style="color:#555">:</span><span style="color:#4fc3f7">~</span><span style="color:#555">$</span>
+          <span class="cmd-echo">${cmd.replace(/</g, '&lt;')}</span>
+        </div>`;
+      const clone = sourceEl.cloneNode(true) as Element;
+      clone.removeAttribute('id');
+      clone.querySelectorAll('[id]').forEach((el) => el.removeAttribute('id'));
+      const wrapper = document.createElement('div');
+      wrapper.className = 'cmd-line';
+      wrapper.style.display = 'block';
+      wrapper.style.marginTop = '6px';
+      wrapper.appendChild(clone);
+      block.appendChild(wrapper);
+      cmdOutput!.appendChild(block);
+      window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+    }
+
     async function handleCommand(raw: string) {
       const cmd = raw.trim().toLowerCase();
       if (!cmd || busy) return;
@@ -1037,6 +1060,24 @@ const experienceYears = currentYear - 2012;
         await brewCoffee();
         setPromptVisible(true);
         busy = false;
+        return;
+      }
+
+      if (cmd === 'neofetch') {
+        const src = document.querySelector('#chafa');
+        if (src) appendClonedSection(raw.trim(), src);
+        return;
+      }
+
+      if (cmd === 'man meik') {
+        const src = document.querySelector('.man-output');
+        if (src) appendClonedSection(raw.trim(), src);
+        return;
+      }
+
+      if (cmd === 'column -t experience.tsv') {
+        const src = document.querySelector('.exp-table');
+        if (src) appendClonedSection(raw.trim(), src);
         return;
       }
 


### PR DESCRIPTION
## Summary

- Typing `neofetch` in the terminal re-renders the profile/system info block inline
- Typing `man meik` renders the full man page inline in the output
- Typing `column -t experience.tsv` renders the experience table inline
- `help` updated to list all three new commands
- DOM-cloning approach — output inherits all existing CSS, no duplication of content

## Test Plan

- [x] 4 new Playwright e2e tests (all green)
- [x] Full suite: 37/37 passed
- [x] `help` lists the new commands
- [x] Unknown commands still show `zsh: command not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)